### PR TITLE
Add "transient" hint for notification

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -72,6 +72,9 @@ void notifications_flash(void)
     // Update the notification volume
     notify_notification_set_hint_int32(notification, "value", (gint)as->volume);
 
+    // Add transient flag
+    notify_notification_set_hint_int32(notification, "transient", (gint)1);
+    
     // Update the notification icon
     notify_notification_update(notification, PROGRAM_NAME, NULL, icon_name);
 


### PR DESCRIPTION
I think that adding this flag make sense. For example when using xfce4-notifyd and enabled logging, every change of volume is stored in history, but if notification is marked as transient, then it's skipped in log.