### PR TITLE
Ignore deprecated warnings

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,7 @@ pa_applet_SOURCES = \
     volume_scale.h
 
 pa_applet_CPPFLAGS = \
-    -std=c99 -D_GNU_SOURCE -Wall -Werror \
+    -std=c99 -D_GNU_SOURCE -Wall -Werror -Wno-error=deprecated-declarations \
     $(GLIB_CFLAGS) \
     $(GTK3_CFLAGS) \
     $(LIBPULSE_CFLAGS) \


### PR DESCRIPTION
Compilation fails on recent versions of GDK due to various
`deprecated-declarations` warnings

`GtkStatusIcon` is now deprecated and without a direct alternative.

* Ignore `deprecated-declarations` going forward