### PR TITLE
fixes notification issue

### DIFF
--- a/README
+++ b/README
@@ -108,3 +108,7 @@ Authors
 pa-applet was created by:
 
 Fernando Tarlá Cardoso Lemos <fernandotcl AT gmail.com>
+
+Notification patch created by:
+
+Michael Mao

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -73,7 +73,12 @@ void notifications_flash(void)
     notify_notification_set_hint_int32(notification, "value", (gint)as->volume);
 
     // Update the notification icon
-    notify_notification_update(notification, PROGRAM_NAME, NULL, icon_name);
+    char vol[4];
+    char notification_str[12];
+    sprintf(vol, "%d", (gint)as->volume);
+    strcpy(notification_str, "Volume: ");
+    strcat(notification_str, vol);
+    notify_notification_update(notification, notification_str, NULL, icon_name);
 
     // Show the notification
     notify_notification_show(notification, NULL);


### PR DESCRIPTION
pa-applet notification only shows "pa-applet" when changing volume through media buttons on awesome. This change fixes issue #16 by changing the update notification text. Did not test on other window managers, may cause unexpected behavior in other window managers. 